### PR TITLE
Give markDefs a fallback value if it is null

### DIFF
--- a/src/buildMarksTree.ts
+++ b/src/buildMarksTree.ts
@@ -42,7 +42,8 @@ import type {ToolkitNestedPortableTextSpan, ToolkitTextNode} from './types'
 export function buildMarksTree<M extends PortableTextMarkDefinition = PortableTextMarkDefinition>(
   block: PortableTextBlock<M>,
 ): (ToolkitNestedPortableTextSpan<M> | ToolkitTextNode | ArbitraryTypedObject)[] {
-  const {children, markDefs = []} = block
+  const {children} = block
+  const markDefs = block.markDefs ?? []
   if (!children || !children.length) {
     return []
   }


### PR DESCRIPTION
Default values during a destructuring assignment are not used when the value is null.  

[Example from MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#default_value):

```js
const [a = 1] = []; // a is 1
const { b = 2 } = { b: undefined }; // b is 2
const { c = 2 } = { c: null }; // c is null
```

I encountered this PortableText block:
```json
[
  {
    "_type": "block",
    "style": "normal",
    "_key": "3f2160c15ba9",
    "children": [
      {
        "_type": "span",
        "marks": [
          "em"
        ],
        "text": "Example",
        "_key": "d8bf318b9723"
      }
    ]
  }
]
```

This caused rendering to crash when using the PortableText component from portabletext/react. 
Specifically `./src/buildMarksTree.ts:93` `Error: Cannot read properties of null (reading 'find')`