### PR TITLE
fix: prevent double spaces in `toPlainText` when span follows non-span

### DIFF
--- a/src/toPlainText.ts
+++ b/src/toPlainText.ts
@@ -3,7 +3,7 @@ import type {ArbitraryTypedObject, PortableTextBlock} from '@portabletext/types'
 import {isPortableTextBlock, isPortableTextSpan} from './asserters'
 
 const leadingSpace = /^\s/
-const trailingSpace = /^\s/
+const trailingSpace = /\s$/
 
 /**
  * Takes a Portable Text block (or an array of them) and returns the text value

--- a/test/toPlainText.test.ts
+++ b/test/toPlainText.test.ts
@@ -134,3 +134,16 @@ test('toPlainText: does not add leading whitespace on span-hugging non-span', ()
     }),
   ).toEqual('Now that is an image.')
 })
+
+test('toPlainText: does not add leading whitespace on span-hugging non-span (trailing)', () => {
+  expect(
+    toPlainText({
+      _type: 'block',
+      children: [
+        {_type: 'span', text: 'Now that is a '},
+        {_type: 'image', src: '/some/image.png'},
+        {_type: 'span', text: 'beautiful image.'},
+      ],
+    }),
+  ).toEqual('Now that is a beautiful image.')
+})


### PR DESCRIPTION
Bit of an edge case, but this was the intention all along, although a faulty regex prevented this from actually being applied:

When calling `toPlainText()` on a block that has a span that ends with a space, then is followed by a non-span, then followed by a span - it currently adds an additional space. It should instead only add one if there is _no_ space between the two spans.