### PR TITLE
fix!: nest lists as deeply as their level says

### DIFF
--- a/.changeset/lazy-moons-attack.md
+++ b/.changeset/lazy-moons-attack.md
@@ -1,0 +1,8 @@
+---
+'@portabletext/toolkit': major
+---
+
+Require Node.js 22.12 or later, and drop the legacy `main` and `module` fields
+
+The package has been ESM-only for a while, but still carried `main` and `module` entry points for
+resolvers that predate `exports`. Those are gone, so the package resolves through `exports` only.

--- a/.changeset/quiet-jokes-repeat.md
+++ b/.changeset/quiet-jokes-repeat.md
@@ -1,0 +1,17 @@
+---
+'@portabletext/toolkit': major
+---
+
+`nestLists()` now nests every list as deeply as its `level` says it is
+
+List items can start at a level deeper than 1, and can skip any number of levels at a time.
+`nestLists()` previously ignored both, so a level 3 item could end up as a list nested only one
+level deep, and items that later returned to a shallower level could fail to rejoin the list they
+belonged to and be emitted as a separate sibling list instead.
+
+The levels that were never authored are now generated, so nesting depth always matches `level`.
+A generated list holds an empty list item in `html` mode, since HTML can only nest a list inside a
+list item, and holds nothing but the deeper list in `direct` mode.
+
+This changes the output of `nestLists()` for any input where a list starts deeper than level 1 or
+skips a level, and therefore changes the rendered output of anything built on it.

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./src/index.ts",
@@ -67,7 +65,7 @@
     "vitest": "^4.1.2"
   },
   "engines": {
-    "node": ">=20.19 <22 || >=22.12"
+    "node": ">=22.12"
   },
   "packageManager": "pnpm@10.30.3"
 }

--- a/src/nestLists.ts
+++ b/src/nestLists.ts
@@ -10,7 +10,6 @@ import type {
   ToolkitPortableTextDirectList,
   ToolkitPortableTextHtmlList,
   ToolkitPortableTextList,
-  ToolkitPortableTextListItem,
 } from './types'
 
 export type ToolkitNestListsOutputNode<T> =
@@ -35,6 +34,12 @@ export type ToolkitNestListsOutputNode<T> =
  * while with `html` they will be of type {@link ToolkitPortableTextHtmlList}
  *
  * These modes are available as {@link LIST_NEST_MODE_HTML} and {@link LIST_NEST_MODE_DIRECT}.
+ *
+ * In both modes, a list node is always nested as deeply as its `level` says it is. List items can
+ * start at any level and skip any number of levels, so the levels that were never authored are
+ * generated to keep the two in sync - meaning renderers can indent by tree depth or by `level` and
+ * get the same result. A generated list holds an empty list item in `html` mode, since HTML can
+ * only nest a list inside a list item, and holds nothing but the deeper list in `direct` mode.
  *
  * @param blocks - Array of Portable Text blocks and other arbitrary types
  * @param mode - Mode to use for nesting, `direct` or `html`
@@ -73,8 +78,9 @@ export function nestLists<T extends TypedObject = PortableTextBlock | TypedObjec
 
     // Start of a new list?
     if (!currentList) {
-      currentList = listFromBlock(block, i, mode)
-      tree.push(currentList)
+      const nestedLists = createNestedLists(block, i, mode, 0)
+      currentList = nestedLists.current
+      tree.push(nestedLists.root)
       continue
     }
 
@@ -86,35 +92,9 @@ export function nestLists<T extends TypedObject = PortableTextBlock | TypedObjec
 
     // Different list props, are we going deeper?
     if ((block.level || 1) > currentList.level) {
-      const newList = listFromBlock(block, i, mode)
-
-      if (mode === 'html') {
-        // Because HTML is kinda weird, nested lists needs to be nested within list items.
-        // So while you would think that we could populate the parent list with a new sub-list,
-        // we actually have to target the last list element (child) of the parent.
-        // However, at this point we need to be very careful - simply pushing to the list of children
-        // will mutate the input, and we don't want to blindly clone the entire tree.
-
-        // Clone the last child while adding our new list as the last child of it
-        const lastListItem = currentList.children[
-          currentList.children.length - 1
-        ] as ToolkitPortableTextListItem
-
-        const newLastChild: ToolkitPortableTextListItem = {
-          ...lastListItem,
-          children: [...lastListItem.children, newList],
-        }
-
-        // Swap the last child
-        currentList.children[currentList.children.length - 1] = newLastChild
-      } else {
-        ;(currentList as ToolkitPortableTextDirectList).children.push(
-          newList as ToolkitPortableTextDirectList,
-        )
-      }
-
-      // Set the newly created, deeper list as the current
-      currentList = newList
+      const nestedLists = createNestedLists(block, i, mode, currentList.level)
+      appendNestedList(currentList, nestedLists.root)
+      currentList = nestedLists.current
       continue
     }
 
@@ -130,8 +110,9 @@ export function nestLists<T extends TypedObject = PortableTextBlock | TypedObjec
       }
 
       // Similar parent can't be found, assume new list
-      currentList = listFromBlock(block, i, mode)
-      tree.push(currentList)
+      const nestedLists = createNestedLists(block, i, mode, 0)
+      currentList = nestedLists.current
+      tree.push(nestedLists.root)
       continue
     }
 
@@ -144,8 +125,9 @@ export function nestLists<T extends TypedObject = PortableTextBlock | TypedObjec
         currentList.children.push(block)
         continue
       } else {
-        currentList = listFromBlock(block, i, mode)
-        tree.push(currentList)
+        const nestedLists = createNestedLists(block, i, mode, 0)
+        currentList = nestedLists.current
+        tree.push(nestedLists.root)
         continue
       }
     }
@@ -166,14 +148,98 @@ function listFromBlock(
   block: PortableTextListItemBlock,
   index: number,
   mode: ToolkitListNestMode,
+  level: number,
+  children: PortableTextListItemBlock[],
 ): ToolkitPortableTextList {
-  return {
-    _type: '@list',
-    _key: `${block._key || `${index}`}-parent`,
+  // Generated ancestor lists share the block's key, so they need the level to stay unique
+  const suffix = level === (block.level || 1) ? '' : `-${level}`
+  const key = `${block._key || `${index}`}-parent${suffix}`
+  return {_type: '@list', _key: key, mode, level, listItem: block.listItem, children}
+}
+
+function createNestedLists(
+  block: PortableTextListItemBlock,
+  index: number,
+  mode: ToolkitListNestMode,
+  startLevel: number,
+): {root: ToolkitPortableTextList; current: ToolkitPortableTextList} {
+  const level = block.level || 1
+  const firstLevel = startLevel + 1
+  const root = listFromBlock(
+    block,
+    index,
     mode,
-    level: block.level || 1,
-    listItem: block.listItem,
-    children: [block],
+    firstLevel,
+    listChildren(block, index, mode, firstLevel, level),
+  )
+  let current = root
+
+  for (let listLevel = firstLevel + 1; listLevel <= level; listLevel++) {
+    const list = listFromBlock(
+      block,
+      index,
+      mode,
+      listLevel,
+      listChildren(block, index, mode, listLevel, level),
+    )
+    appendNestedList(current, list)
+    current = list
+  }
+
+  return {root, current}
+}
+
+function listChildren(
+  block: PortableTextListItemBlock,
+  index: number,
+  mode: ToolkitListNestMode,
+  listLevel: number,
+  targetLevel: number,
+): PortableTextListItemBlock[] {
+  if (listLevel === targetLevel) {
+    return [block]
+  }
+
+  return mode === 'html' ? [emptyListItemFromBlock(block, index, listLevel)] : []
+}
+
+function emptyListItemFromBlock(
+  block: PortableTextListItemBlock,
+  index: number,
+  level: number,
+): PortableTextListItemBlock {
+  return {
+    ...block,
+    _key: `${block._key || `${index}`}-placeholder-${level}`,
+    children: [],
+    level,
+  }
+}
+
+// Both lists are always created with the same mode, so the mixed cases cannot occur
+function appendNestedList(parentList: ToolkitPortableTextList, childList: ToolkitPortableTextList) {
+  if (parentList.mode === 'html' && childList.mode === 'html') {
+    // Because HTML is kinda weird, nested lists needs to be nested within list items.
+    // So while you would think that we could populate the parent list with a new sub-list,
+    // we actually have to target the last list element (child) of the parent.
+    // However, at this point we need to be very careful - simply pushing to the list of children
+    // will mutate the input, and we don't want to blindly clone the entire tree.
+    const lastIndex = parentList.children.length - 1
+    const lastListItem = parentList.children[lastIndex]
+    if (!lastListItem) {
+      return
+    }
+
+    // Swap the last child for a clone that holds our new list as its last child
+    parentList.children[lastIndex] = {
+      ...lastListItem,
+      children: [...lastListItem.children, childList],
+    }
+    return
+  }
+
+  if (parentList.mode === 'direct' && childList.mode === 'direct') {
+    parentList.children.push(childList)
   }
 }
 

--- a/test/__snapshots__/nestLists.test.ts.snap
+++ b/test/__snapshots__/nestLists.test.ts.snap
@@ -119,6 +119,1036 @@ exports[`nestLists: ends lists when non-list item occurs 1`] = `
 ]
 `;
 
+exports[`nestLists: fills skipped levels for 'initial level' in direct mode 1`] = `
+[
+  {
+    "_key": "level-3-parent-1",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-3-parent-2",
+        "_type": "@list",
+        "children": [
+          {
+            "_key": "level-3-parent",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-3",
+                "_type": "block",
+                "children": [
+                  {
+                    "_type": "span",
+                    "text": "Level 3",
+                  },
+                ],
+                "level": 3,
+                "listItem": "bullet",
+              },
+            ],
+            "level": 3,
+            "listItem": "bullet",
+            "mode": "direct",
+          },
+        ],
+        "level": 2,
+        "listItem": "bullet",
+        "mode": "direct",
+      },
+      {
+        "_key": "level-1",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "direct",
+  },
+]
+`;
+
+exports[`nestLists: fills skipped levels for 'initial level' in html mode 1`] = `
+[
+  {
+    "_key": "level-3-parent-1",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-3-placeholder-1",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "level-3-parent-2",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-3-placeholder-2",
+                "_type": "block",
+                "children": [
+                  {
+                    "_key": "level-3-parent",
+                    "_type": "@list",
+                    "children": [
+                      {
+                        "_key": "level-3",
+                        "_type": "block",
+                        "children": [
+                          {
+                            "_type": "span",
+                            "text": "Level 3",
+                          },
+                        ],
+                        "level": 3,
+                        "listItem": "bullet",
+                      },
+                    ],
+                    "level": 3,
+                    "listItem": "bullet",
+                    "mode": "html",
+                  },
+                ],
+                "level": 2,
+                "listItem": "bullet",
+              },
+            ],
+            "level": 2,
+            "listItem": "bullet",
+            "mode": "html",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+      {
+        "_key": "level-1",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "html",
+  },
+]
+`;
+
+exports[`nestLists: fills skipped levels for 'same level without a matching list st…' in direct mode 1`] = `
+[
+  {
+    "_key": "level-1-parent",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-1",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+      {
+        "_key": "level-2-number-parent",
+        "_type": "@list",
+        "children": [
+          {
+            "_key": "level-2-number",
+            "_type": "block",
+            "children": [
+              {
+                "_type": "span",
+                "text": "Level 2 number",
+              },
+            ],
+            "level": 2,
+            "listItem": "number",
+          },
+        ],
+        "level": 2,
+        "listItem": "number",
+        "mode": "direct",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "direct",
+  },
+  {
+    "_key": "level-2-parent-1",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-2-parent",
+        "_type": "@list",
+        "children": [
+          {
+            "_key": "level-2",
+            "_type": "block",
+            "children": [
+              {
+                "_type": "span",
+                "text": "Level 2",
+              },
+            ],
+            "level": 2,
+            "listItem": "bullet",
+          },
+        ],
+        "level": 2,
+        "listItem": "bullet",
+        "mode": "direct",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "direct",
+  },
+]
+`;
+
+exports[`nestLists: fills skipped levels for 'same level without a matching list st…' in html mode 1`] = `
+[
+  {
+    "_key": "level-1-parent",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-1",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1",
+          },
+          {
+            "_key": "level-2-number-parent",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-2-number",
+                "_type": "block",
+                "children": [
+                  {
+                    "_type": "span",
+                    "text": "Level 2 number",
+                  },
+                ],
+                "level": 2,
+                "listItem": "number",
+              },
+            ],
+            "level": 2,
+            "listItem": "number",
+            "mode": "html",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "html",
+  },
+  {
+    "_key": "level-2-parent-1",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-2-placeholder-1",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "level-2-parent",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-2",
+                "_type": "block",
+                "children": [
+                  {
+                    "_type": "span",
+                    "text": "Level 2",
+                  },
+                ],
+                "level": 2,
+                "listItem": "bullet",
+              },
+            ],
+            "level": 2,
+            "listItem": "bullet",
+            "mode": "html",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "html",
+  },
+]
+`;
+
+exports[`nestLists: fills skipped levels for 'shallower level without a matching an…' in direct mode 1`] = `
+[
+  {
+    "_key": "level-1-parent",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-1",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+      {
+        "_key": "level-3-number-parent-2",
+        "_type": "@list",
+        "children": [
+          {
+            "_key": "level-3-number-parent",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-3-number",
+                "_type": "block",
+                "children": [
+                  {
+                    "_type": "span",
+                    "text": "Level 3 number",
+                  },
+                ],
+                "level": 3,
+                "listItem": "number",
+              },
+            ],
+            "level": 3,
+            "listItem": "number",
+            "mode": "direct",
+          },
+        ],
+        "level": 2,
+        "listItem": "number",
+        "mode": "direct",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "direct",
+  },
+  {
+    "_key": "level-2-parent-1",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-2-parent",
+        "_type": "@list",
+        "children": [
+          {
+            "_key": "level-2",
+            "_type": "block",
+            "children": [
+              {
+                "_type": "span",
+                "text": "Level 2",
+              },
+            ],
+            "level": 2,
+            "listItem": "bullet",
+          },
+        ],
+        "level": 2,
+        "listItem": "bullet",
+        "mode": "direct",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "direct",
+  },
+]
+`;
+
+exports[`nestLists: fills skipped levels for 'shallower level without a matching an…' in html mode 1`] = `
+[
+  {
+    "_key": "level-1-parent",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-1",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1",
+          },
+          {
+            "_key": "level-3-number-parent-2",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-3-number-placeholder-2",
+                "_type": "block",
+                "children": [
+                  {
+                    "_key": "level-3-number-parent",
+                    "_type": "@list",
+                    "children": [
+                      {
+                        "_key": "level-3-number",
+                        "_type": "block",
+                        "children": [
+                          {
+                            "_type": "span",
+                            "text": "Level 3 number",
+                          },
+                        ],
+                        "level": 3,
+                        "listItem": "number",
+                      },
+                    ],
+                    "level": 3,
+                    "listItem": "number",
+                    "mode": "html",
+                  },
+                ],
+                "level": 2,
+                "listItem": "number",
+              },
+            ],
+            "level": 2,
+            "listItem": "number",
+            "mode": "html",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "html",
+  },
+  {
+    "_key": "level-2-parent-1",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-2-placeholder-1",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "level-2-parent",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-2",
+                "_type": "block",
+                "children": [
+                  {
+                    "_type": "span",
+                    "text": "Level 2",
+                  },
+                ],
+                "level": 2,
+                "listItem": "bullet",
+              },
+            ],
+            "level": 2,
+            "listItem": "bullet",
+            "mode": "html",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "html",
+  },
+]
+`;
+
+exports[`nestLists: fills skipped levels for 'skipped level while nesting' in direct mode 1`] = `
+[
+  {
+    "_key": "level-1-parent",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-1",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+      {
+        "_key": "level-3-parent-2",
+        "_type": "@list",
+        "children": [
+          {
+            "_key": "level-3-parent",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-3",
+                "_type": "block",
+                "children": [
+                  {
+                    "_type": "span",
+                    "text": "Level 3",
+                  },
+                ],
+                "level": 3,
+                "listItem": "bullet",
+              },
+            ],
+            "level": 3,
+            "listItem": "bullet",
+            "mode": "direct",
+          },
+        ],
+        "level": 2,
+        "listItem": "bullet",
+        "mode": "direct",
+      },
+      {
+        "_key": "level-1-again",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1 again",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "direct",
+  },
+]
+`;
+
+exports[`nestLists: fills skipped levels for 'skipped level while nesting' in html mode 1`] = `
+[
+  {
+    "_key": "level-1-parent",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-1",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1",
+          },
+          {
+            "_key": "level-3-parent-2",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-3-placeholder-2",
+                "_type": "block",
+                "children": [
+                  {
+                    "_key": "level-3-parent",
+                    "_type": "@list",
+                    "children": [
+                      {
+                        "_key": "level-3",
+                        "_type": "block",
+                        "children": [
+                          {
+                            "_type": "span",
+                            "text": "Level 3",
+                          },
+                        ],
+                        "level": 3,
+                        "listItem": "bullet",
+                      },
+                    ],
+                    "level": 3,
+                    "listItem": "bullet",
+                    "mode": "html",
+                  },
+                ],
+                "level": 2,
+                "listItem": "bullet",
+              },
+            ],
+            "level": 2,
+            "listItem": "bullet",
+            "mode": "html",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+      {
+        "_key": "level-1-again",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1 again",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "html",
+  },
+]
+`;
+
+exports[`nestLists: fills skipped levels for 'skipped levels with a changed list st…' in direct mode 1`] = `
+[
+  {
+    "_key": "level-3-bullet-parent-1",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-3-bullet-parent-2",
+        "_type": "@list",
+        "children": [
+          {
+            "_key": "level-3-bullet-parent",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-3-bullet",
+                "_type": "block",
+                "children": [
+                  {
+                    "_type": "span",
+                    "text": "Level 3 bullet",
+                  },
+                ],
+                "level": 3,
+                "listItem": "bullet",
+              },
+            ],
+            "level": 3,
+            "listItem": "bullet",
+            "mode": "direct",
+          },
+        ],
+        "level": 2,
+        "listItem": "bullet",
+        "mode": "direct",
+      },
+      {
+        "_key": "level-1",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+      {
+        "_key": "level-5-bullet-parent-2",
+        "_type": "@list",
+        "children": [
+          {
+            "_key": "level-5-bullet-parent-3",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-5-bullet-parent-4",
+                "_type": "@list",
+                "children": [
+                  {
+                    "_key": "level-5-bullet-parent",
+                    "_type": "@list",
+                    "children": [
+                      {
+                        "_key": "level-5-bullet",
+                        "_type": "block",
+                        "children": [
+                          {
+                            "_type": "span",
+                            "text": "Level 5 bullet",
+                          },
+                        ],
+                        "level": 5,
+                        "listItem": "bullet",
+                      },
+                    ],
+                    "level": 5,
+                    "listItem": "bullet",
+                    "mode": "direct",
+                  },
+                ],
+                "level": 4,
+                "listItem": "bullet",
+                "mode": "direct",
+              },
+            ],
+            "level": 3,
+            "listItem": "bullet",
+            "mode": "direct",
+          },
+          {
+            "_key": "level-2-bullet",
+            "_type": "block",
+            "children": [
+              {
+                "_type": "span",
+                "text": "Level 2 bullet",
+              },
+            ],
+            "level": 2,
+            "listItem": "bullet",
+          },
+          {
+            "_key": "level-5-number-parent-3",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-5-number-parent-4",
+                "_type": "@list",
+                "children": [
+                  {
+                    "_key": "level-5-number-parent",
+                    "_type": "@list",
+                    "children": [
+                      {
+                        "_key": "level-5-number",
+                        "_type": "block",
+                        "children": [
+                          {
+                            "_type": "span",
+                            "text": "Level 5 number",
+                          },
+                        ],
+                        "level": 5,
+                        "listItem": "number",
+                      },
+                    ],
+                    "level": 5,
+                    "listItem": "number",
+                    "mode": "direct",
+                  },
+                ],
+                "level": 4,
+                "listItem": "number",
+                "mode": "direct",
+              },
+            ],
+            "level": 3,
+            "listItem": "number",
+            "mode": "direct",
+          },
+        ],
+        "level": 2,
+        "listItem": "bullet",
+        "mode": "direct",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "direct",
+  },
+  {
+    "_key": "level-1-number-parent",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-1-number",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1 number",
+          },
+        ],
+        "level": 1,
+        "listItem": "number",
+      },
+    ],
+    "level": 1,
+    "listItem": "number",
+    "mode": "direct",
+  },
+]
+`;
+
+exports[`nestLists: fills skipped levels for 'skipped levels with a changed list st…' in html mode 1`] = `
+[
+  {
+    "_key": "level-3-bullet-parent-1",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-3-bullet-placeholder-1",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "level-3-bullet-parent-2",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-3-bullet-placeholder-2",
+                "_type": "block",
+                "children": [
+                  {
+                    "_key": "level-3-bullet-parent",
+                    "_type": "@list",
+                    "children": [
+                      {
+                        "_key": "level-3-bullet",
+                        "_type": "block",
+                        "children": [
+                          {
+                            "_type": "span",
+                            "text": "Level 3 bullet",
+                          },
+                        ],
+                        "level": 3,
+                        "listItem": "bullet",
+                      },
+                    ],
+                    "level": 3,
+                    "listItem": "bullet",
+                    "mode": "html",
+                  },
+                ],
+                "level": 2,
+                "listItem": "bullet",
+              },
+            ],
+            "level": 2,
+            "listItem": "bullet",
+            "mode": "html",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+      {
+        "_key": "level-1",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1",
+          },
+          {
+            "_key": "level-5-bullet-parent-2",
+            "_type": "@list",
+            "children": [
+              {
+                "_key": "level-5-bullet-placeholder-2",
+                "_type": "block",
+                "children": [
+                  {
+                    "_key": "level-5-bullet-parent-3",
+                    "_type": "@list",
+                    "children": [
+                      {
+                        "_key": "level-5-bullet-placeholder-3",
+                        "_type": "block",
+                        "children": [
+                          {
+                            "_key": "level-5-bullet-parent-4",
+                            "_type": "@list",
+                            "children": [
+                              {
+                                "_key": "level-5-bullet-placeholder-4",
+                                "_type": "block",
+                                "children": [
+                                  {
+                                    "_key": "level-5-bullet-parent",
+                                    "_type": "@list",
+                                    "children": [
+                                      {
+                                        "_key": "level-5-bullet",
+                                        "_type": "block",
+                                        "children": [
+                                          {
+                                            "_type": "span",
+                                            "text": "Level 5 bullet",
+                                          },
+                                        ],
+                                        "level": 5,
+                                        "listItem": "bullet",
+                                      },
+                                    ],
+                                    "level": 5,
+                                    "listItem": "bullet",
+                                    "mode": "html",
+                                  },
+                                ],
+                                "level": 4,
+                                "listItem": "bullet",
+                              },
+                            ],
+                            "level": 4,
+                            "listItem": "bullet",
+                            "mode": "html",
+                          },
+                        ],
+                        "level": 3,
+                        "listItem": "bullet",
+                      },
+                    ],
+                    "level": 3,
+                    "listItem": "bullet",
+                    "mode": "html",
+                  },
+                ],
+                "level": 2,
+                "listItem": "bullet",
+              },
+              {
+                "_key": "level-2-bullet",
+                "_type": "block",
+                "children": [
+                  {
+                    "_type": "span",
+                    "text": "Level 2 bullet",
+                  },
+                  {
+                    "_key": "level-5-number-parent-3",
+                    "_type": "@list",
+                    "children": [
+                      {
+                        "_key": "level-5-number-placeholder-3",
+                        "_type": "block",
+                        "children": [
+                          {
+                            "_key": "level-5-number-parent-4",
+                            "_type": "@list",
+                            "children": [
+                              {
+                                "_key": "level-5-number-placeholder-4",
+                                "_type": "block",
+                                "children": [
+                                  {
+                                    "_key": "level-5-number-parent",
+                                    "_type": "@list",
+                                    "children": [
+                                      {
+                                        "_key": "level-5-number",
+                                        "_type": "block",
+                                        "children": [
+                                          {
+                                            "_type": "span",
+                                            "text": "Level 5 number",
+                                          },
+                                        ],
+                                        "level": 5,
+                                        "listItem": "number",
+                                      },
+                                    ],
+                                    "level": 5,
+                                    "listItem": "number",
+                                    "mode": "html",
+                                  },
+                                ],
+                                "level": 4,
+                                "listItem": "number",
+                              },
+                            ],
+                            "level": 4,
+                            "listItem": "number",
+                            "mode": "html",
+                          },
+                        ],
+                        "level": 3,
+                        "listItem": "number",
+                      },
+                    ],
+                    "level": 3,
+                    "listItem": "number",
+                    "mode": "html",
+                  },
+                ],
+                "level": 2,
+                "listItem": "bullet",
+              },
+            ],
+            "level": 2,
+            "listItem": "bullet",
+            "mode": "html",
+          },
+        ],
+        "level": 1,
+        "listItem": "bullet",
+      },
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "mode": "html",
+  },
+  {
+    "_key": "level-1-number-parent",
+    "_type": "@list",
+    "children": [
+      {
+        "_key": "level-1-number",
+        "_type": "block",
+        "children": [
+          {
+            "_type": "span",
+            "text": "Level 1 number",
+          },
+        ],
+        "level": 1,
+        "listItem": "number",
+      },
+    ],
+    "level": 1,
+    "listItem": "number",
+    "mode": "html",
+  },
+]
+`;
+
 exports[`nestLists: handles deeper/shallower transitions correctly in direct mode 1`] = `
 [
   {

--- a/test/fixtures/nestLists.ts
+++ b/test/fixtures/nestLists.ts
@@ -1,0 +1,55 @@
+import type {PortableTextListItemBlock} from '@portabletext/types'
+
+function listItem(
+  text: string,
+  level: number,
+  listItemStyle = 'bullet',
+): PortableTextListItemBlock {
+  return {
+    _type: 'block',
+    _key: text.toLowerCase().replaceAll(' ', '-'),
+    children: [{_type: 'span', text}],
+    level,
+    listItem: listItemStyle,
+  }
+}
+
+export const listNestingFixtures = [
+  {
+    name: 'initial level',
+    blocks: [listItem('Level 3', 3), listItem('Level 1', 1)],
+  },
+  {
+    name: 'skipped level while nesting',
+    blocks: [listItem('Level 1', 1), listItem('Level 3', 3), listItem('Level 1 again', 1)],
+  },
+  {
+    // Goes back up to a level that has no matching ancestor, so a new branch has to be started
+    name: 'shallower level without a matching ancestor',
+    blocks: [
+      listItem('Level 1', 1),
+      listItem('Level 3 number', 3, 'number'),
+      listItem('Level 2', 2),
+    ],
+  },
+  {
+    // Same level as the current list, but neither it nor any ancestor uses the incoming style
+    name: 'same level without a matching list style',
+    blocks: [
+      listItem('Level 1', 1),
+      listItem('Level 2 number', 2, 'number'),
+      listItem('Level 2', 2),
+    ],
+  },
+  {
+    name: 'skipped levels with a changed list style',
+    blocks: [
+      listItem('Level 3 bullet', 3),
+      listItem('Level 1', 1),
+      listItem('Level 5 bullet', 5),
+      listItem('Level 2 bullet', 2),
+      listItem('Level 5 number', 5, 'number'),
+      listItem('Level 1 number', 1, 'number'),
+    ],
+  },
+]

--- a/test/nestLists.test.ts
+++ b/test/nestLists.test.ts
@@ -1,6 +1,14 @@
-import {LIST_NEST_MODE_DIRECT, LIST_NEST_MODE_HTML, nestLists} from '@portabletext/toolkit'
-import type {PortableTextListItemBlock} from '@portabletext/types'
+import {
+  isPortableTextListItemBlock,
+  isPortableTextToolkitList,
+  LIST_NEST_MODE_DIRECT,
+  LIST_NEST_MODE_HTML,
+  nestLists,
+} from '@portabletext/toolkit'
+import type {PortableTextListItemBlock, TypedObject} from '@portabletext/types'
 import {expect, test} from 'vitest'
+
+import {listNestingFixtures} from './fixtures/nestLists'
 
 test('nestLists: returns empty tree on no blocks', () => {
   expect(nestLists([], LIST_NEST_MODE_HTML)).toEqual([])
@@ -105,6 +113,20 @@ test('nestLists: handles deeper/shallower transitions correctly in direct mode',
   expect(nestLists(blocks, LIST_NEST_MODE_DIRECT)).toMatchSnapshot()
 })
 
+test.each(listNestingFixtures)(
+  'nestLists: fills skipped levels for $name in html mode',
+  ({blocks}) => {
+    expect(nestLists(blocks, LIST_NEST_MODE_HTML)).toMatchSnapshot()
+  },
+)
+
+test.each(listNestingFixtures)(
+  'nestLists: fills skipped levels for $name in direct mode',
+  ({blocks}) => {
+    expect(nestLists(blocks, LIST_NEST_MODE_DIRECT)).toMatchSnapshot()
+  },
+)
+
 test('nestLists: wraps adjacent list items of different types in separate list nodes', () => {
   const blocks = [
     ...createBlocks(['Bullet 1', 'Bullet 2'], {type: 'bullet', startIndex: 0}),
@@ -112,6 +134,48 @@ test('nestLists: wraps adjacent list items of different types in separate list n
   ]
   expect(nestLists(blocks, LIST_NEST_MODE_HTML)).toMatchSnapshot()
 })
+
+// Both nesting modes carry `level` on every list node, but only `html` mode _needs_ the tree to be
+// as deep as the level, since HTML has no other way of expressing depth. Keeping the two in sync in
+// `direct` mode as well means renderers that indent by tree depth and renderers that indent by
+// `level` agree on the result, whichever mode they pick.
+test.each(listNestingFixtures)('nestLists: nesting depth matches level for $name', ({blocks}) => {
+  expect(depthMismatches(nestLists(blocks, LIST_NEST_MODE_HTML))).toEqual([])
+  expect(depthMismatches(nestLists(blocks, LIST_NEST_MODE_DIRECT))).toEqual([])
+})
+
+function depthMismatches(nodes: TypedObject[]): string[] {
+  const mismatches: string[] = []
+  for (const node of nodes) {
+    collectDepthMismatches(node, 0, mismatches)
+  }
+  return mismatches
+}
+
+function collectDepthMismatches(node: TypedObject, depth: number, mismatches: string[]): void {
+  if (isPortableTextToolkitList(node)) {
+    if (node.level !== depth + 1) {
+      mismatches.push(`list at level ${node.level} is nested ${depth + 1} deep`)
+    }
+
+    for (const child of node.children) {
+      collectDepthMismatches(child, depth + 1, mismatches)
+    }
+    return
+  }
+
+  if (isPortableTextListItemBlock(node)) {
+    if ((node.level || 1) !== depth) {
+      mismatches.push(`list item at level ${node.level} is nested ${depth} deep`)
+    }
+
+    // In html mode a deeper list hangs off the list item rather than the list, so the nested list
+    // is still only one level deeper than the list this item belongs to.
+    for (const child of node.children) {
+      collectDepthMismatches(child, depth, mismatches)
+    }
+  }
+}
 
 function createBlocks(
   spans: string[],


### PR DESCRIPTION
BREAKING CHANGE: `nestLists()` returns a different tree for any input where a list starts deeper than level 1 or skips a level, and therefore changes the rendered output of anything built on it. Lists that neither start deep nor skip a level are unaffected. Fixes #100

BREAKING CHANGE: Node.js 22.12 or later is required, and the package no longer has `main` or `module` fields, so resolvers that do not understand `exports` can no longer load it.

**Note:** This requires some bumps/updates to other modules - I've got those staged but they need this released first for a proper release.